### PR TITLE
Add interactive OpenAI chat support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,3 +7,4 @@
 - Docs stubs for architecture and evaluations plus MkDocs navigation
 - Sample bundle/report artifacts and Makefile helper targets
 - Security, contributing, and code of conduct guides
+- OpenAI backend API/base URL overrides and interactive `noema chat` command

--- a/README.md
+++ b/README.md
@@ -22,6 +22,22 @@ python examples/quickstart.py
 # And prints a tiny metric summary (Brier/ECE/wrong@high-conf).
 ```
 
+### Chatting with a live OpenAI-compatible model
+
+Bring your own API credentials and talk to the control loop directly:
+
+```bash
+# Either export credentials ...
+export OPENAI_API_KEY="sk-..."
+export OPENAI_BASE_URL="https://api.openai.com/v1"  # Optional override
+noema chat --model openai
+
+# ... or pass them as options when launching the chat session
+noema chat --model openai --openai-api-key sk-... --openai-base-url https://api.openai.com/v1
+```
+
+The `OPENAI_BASE_URL` option is useful when targeting self-hosted or Azure-compatible endpoints.
+
 ## Hello, Noema (10-line example)
 
 ```python

--- a/src/noema/core/backends/openai_backend.py
+++ b/src/noema/core/backends/openai_backend.py
@@ -16,11 +16,21 @@ from .base import LLMBackend
 class OpenAIBackend:
     name = "openai"
 
-    def __init__(self, model: str = "gpt-3.5-turbo", temperature: float = 0.2) -> None:
-        api_key = os.getenv("OPENAI_API_KEY")
+    def __init__(
+        self,
+        model: str = "gpt-3.5-turbo",
+        temperature: float = 0.2,
+        api_key: str | None = None,
+        base_url: str | None = None,
+    ) -> None:
+        api_key = api_key or os.getenv("OPENAI_API_KEY")
         if not api_key:
             raise RuntimeError("OPENAI_API_KEY not set")
-        self.client = OpenAI(api_key=api_key)
+        base_url = base_url or os.getenv("OPENAI_BASE_URL")
+        client_kwargs = {"api_key": api_key}
+        if base_url:
+            client_kwargs["base_url"] = base_url
+        self.client = OpenAI(**client_kwargs)
         self.model = model
         self.default_temperature = temperature
 


### PR DESCRIPTION
## Summary
- allow configuring the OpenAI backend with explicit API key and base URL overrides
- add a `noema chat` command for interactive conversations with live LLM backends
- document the new workflow in the README and changelog

## Testing
- PYTHONPATH=src pytest

------
https://chatgpt.com/codex/tasks/task_e_68e0588d3fcc8331954575fb9e62ee5f