### PR TITLE
Handle OpenAI response format requirements

### DIFF
--- a/src/noema/core/backends/openai_backend.py
+++ b/src/noema/core/backends/openai_backend.py
@@ -6,7 +6,7 @@ import os
 from typing import List
 
 try:
-    from openai import OpenAI
+    from openai import BadRequestError, OpenAI
 except ImportError as exc:  # pragma: no cover - optional dependency
     raise ImportError("openai extra required: pip install noema[openai]") from exc
 
@@ -45,16 +45,29 @@ class OpenAIBackend:
         if system:
             messages.append({"role": "system", "content": system})
         messages.append({"role": "user", "content": prompt})
+        response_format = self._response_format()
         try:
-            completion = self.client.chat.completions.create(
-                model=self.model,
-                temperature=temperature if temperature is not None else self.default_temperature,
-                response_format={"type": "json_object"},
-                max_tokens=max_tokens,
+            completion = self._create_completion(
                 messages=messages,
+                temperature=temperature,
+                max_tokens=max_tokens,
+                response_format=response_format,
             )
+        except BadRequestError as exc:  # pragma: no cover - network
+            if "response_format" in str(exc).lower() and response_format.get("type") != "text":
+                try:
+                    completion = self._create_completion(
+                        messages=messages,
+                        temperature=temperature,
+                        max_tokens=max_tokens,
+                        response_format={"type": "text"},
+                    )
+                except Exception as fallback_exc:  # pragma: no cover - network
+                    raise RuntimeError(f"OpenAI error: {fallback_exc}") from fallback_exc
+            else:
+                raise RuntimeError(f"OpenAI error: {exc}") from exc
         except Exception as exc:  # pragma: no cover - network
-            raise RuntimeError(f"OpenAI error: {exc}")
+            raise RuntimeError(f"OpenAI error: {exc}") from exc
         content = completion.choices[0].message.content or "{}"
         return self._ensure_json(content)
 
@@ -66,6 +79,40 @@ class OpenAIBackend:
         except json.JSONDecodeError:
             data = {"text": payload, "confidence": 0.5, "rationale_short": "unstructured"}
         return data
+
+    def _response_format(self) -> dict:
+        return {
+            "type": "json_schema",
+            "json_schema": {
+                "name": "noema_response",
+                "schema": {
+                    "type": "object",
+                    "properties": {
+                        "text": {"type": "string"},
+                        "confidence": {"type": "number"},
+                        "rationale_short": {"type": "string"},
+                    },
+                    "required": ["text", "confidence", "rationale_short"],
+                    "additionalProperties": True,
+                },
+            },
+        }
+
+    def _create_completion(
+        self,
+        *,
+        messages: list[dict[str, str]],
+        temperature: float | None,
+        max_tokens: int,
+        response_format: dict,
+    ):
+        return self.client.chat.completions.create(
+            model=self.model,
+            temperature=temperature if temperature is not None else self.default_temperature,
+            response_format=response_format,
+            max_tokens=max_tokens,
+            messages=messages,
+        )
 
     def embed(self, texts: List[str]) -> List[List[float]]:
         try:


### PR DESCRIPTION
## Summary
- request responses using the OpenAI JSON schema response format while preserving legacy fallback
- centralize chat completion creation to gracefully retry with text responses when JSON schema is rejected

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e05bb1d0208331b2142b7b3e153af2